### PR TITLE
Introduce stylelint and wikimedia-config-stylelint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,11 @@
+{
+	"extends": "stylelint-config-wikimedia",
+	"rules": {
+		"declaration-colon-space-after": null,
+		"font-family-name-quotes": null,
+		"max-empty-lines": null,
+		"no-descending-specificity": null,
+		"selector-no-id": null,
+		"selector-no-vendor-prefix": null
+	}
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,35 @@
+/*!
+ * Grunt file
+ */
+
+/*jshint node:true */
+module.exports = function ( grunt ) {
+	grunt.loadNpmTasks( 'grunt-contrib-watch' );
+	grunt.loadNpmTasks( 'grunt-stylelint' );
+
+	grunt.initConfig( {
+
+		// Lint – Styling
+		stylelint: {
+			src: [
+				'**/*.css',
+				'!css/font-awesome.min.css',
+				'!node_modules/**'
+			]
+		},
+
+		// Development
+		watch: {
+			files: [
+				'**/*.css',
+				'!css/font-awesome.min.css',
+				'.{stylelintrc}'
+			],
+			tasks: 'default'
+		}
+
+	} );
+
+	grunt.registerTask( 'lint', [ 'stylelint' ] );
+	grunt.registerTask( 'default', 'lint' );
+};

--- a/css/admin.css
+++ b/css/admin.css
@@ -1,1 +1,4 @@
-.media-wrapper img { max-width: 200px; height: auto; }
+.media-wrapper img {
+	max-width: 200px;
+	height: auto;
+}

--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -1,2 +1,6 @@
-.coauthors-author-options { float: left; }
-.coauthors_affiliations { margin: 6px 0 0 10px; }
+.coauthors-author-options {
+	float: left;
+}
+.coauthors_affiliations {
+	margin: 6px 0 0 10px;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wikimediablog-wordpresscom",
+  "version": "1.3.0",
+  "description": "Wikimedia Foundation Blog Theme npm packages",
+  "keywords": [
+    "ui"
+  ],
+  "homepage": "https://blog.wikimedia.org/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wikimedia/wikimediablog-wordpresscom.git"
+  },
+  "private": true,
+  "license": "GPL-2.0",
+  "devDependencies": {
+    "grunt": "1.0.1",
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-exec": "1.0.0",
+    "grunt-stylelint": "0.6.0",
+    "stylelint-config-wikimedia": "0.3.0"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
  * Theme name: Wikimedia v2
  * Description: Custom Blog Theme
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: Wikimedia Foundation, Inc.
  * License: GNU General Public License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -66,15 +66,15 @@ a {
 a:hover {
 	text-decoration: underline;
 }
-a img {
-	border: 0;
-}
 
 img {
 	height: auto;
 	max-width: 100%;
 	font-size: 0;
 	vertical-align: middle;
+}
+a img {
+	border: 0;
 }
 
 h1,
@@ -175,12 +175,6 @@ textarea {
 	-webkit-font-smoothing: antialiased;
 }
 
-textarea {
-	overflow: auto;
-	resize: none;
-	-webkit-overflow-scrolling: touch;
-}
-
 input,
 textarea {
 	box-sizing: border-box;
@@ -189,8 +183,8 @@ textarea {
 	box-shadow: none;
 }
 
-input[type="radio"],
-input[type="checkbox"] {
+input[type='radio'],
+input[type='checkbox'] {
 	width: auto;
 	height: auto;
 	padding: 0;
@@ -198,16 +192,16 @@ input[type="checkbox"] {
 }
 
 button,
-input[type="submit"],
-input[type="button"],
-input[type="reset"],
-input[type="email"],
-input[type="number"],
-input[type="search"],
-input[type="password"],
-input[type="tel"],
-input[type="text"],
-input[type="url"],
+input[type='submit'],
+input[type='button'],
+input[type='reset'],
+input[type='email'],
+input[type='number'],
+input[type='search'],
+input[type='password'],
+input[type='tel'],
+input[type='text'],
+input[type='url'],
 textarea {
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -217,9 +211,9 @@ textarea {
 }
 
 button,
-input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
 	cursor: pointer;
 }
 
@@ -232,9 +226,11 @@ input::-moz-focus-inner {
 button {
 	overflow: visible;
 }
+
 textarea {
 	overflow: auto;
 	resize: none;
+	-webkit-overflow-scrolling: touch;
 }
 
 ::-webkit-search-cancel-button {
@@ -453,7 +449,7 @@ img.alignnone,
 	width: 32px;
 	height: 100%;
 	border: 0;
-	font-size: 0px;
+	font-size: 0;
 	color: transparent;
 	background: url( images/ico-search.png ) no-repeat center center;
 }
@@ -643,7 +639,7 @@ img.alignnone,
 	display: block;
 	padding-bottom: 4px;
 }
-.comment-respond input[type="text"],
+.comment-respond input[type='text'],
 .comment-respond textarea {
 	display: block;
 	width: 80%;
@@ -653,29 +649,25 @@ img.alignnone,
 	-webkit-transition: background 0.3s ease;
 	transition: background 0.3s ease;
 }
-.comment-respond input[type="text"]:focus,
+.comment-respond input[type='text']:focus,
 .comment-respond textarea:focus {
 	background: #fff;
+}
+.comment-respond input[type='text']::-webkit-input-placeholder {
+	color: #777;
+}
+.comment-respond input[type='text']::-moz-placeholder {
+	color: #777;
+}
+.comment-respond input[type='text']:-ms-input-placeholder {
+	color: #777;
+}
+.comment-respond input[type='text']::placeholder {
+	color: #777;
 }
 .comment-respond textarea {
 	width: 100%;
 	height: 100px;
-}
-.comment-respond input[type="text"]::-webkit-input-placeholder {
-	color: #777;
-}
-.comment-respond input[type="text"]::-moz-placeholder {
-	color: #777;
-}
-.comment-respond input[type="text"]:-ms-input-placeholder {
-	color: #777;
-}
-.comment-respond input[type="text"]::placeholder {
-	color: #777;
-}
-
-.comment-respond textarea {
-	width: 100%;
 }
 .comment-respond .comment-notes {
 	padding-top: 15px;
@@ -734,7 +726,7 @@ img.alignnone,
 	#Containers
 \* ------------------------------------------------------------ */
 
-.wrapper {}
+/* .wrapper {} */
 
 .shell {
 	width: 1086px;
@@ -849,12 +841,12 @@ img.alignnone,
 	right: 12px;
 	font-size: 11px;
 	letter-spacing: 1px;
-	color: rgba( 255, 255, 255, .6 );
+	color: rgba( 255, 255, 255, 0.6 );
 	max-width: 300px;
 }
 .featured-image .author-credentials a {
 	text-decoration: underline;
-	color: rgba( 255, 255, 255, .6 );
+	color: rgba( 255, 255, 255, 0.6 );
 }
 .featured-image .author-credentials a:hover {
 	color: rgba( 255, 255, 255, 1 );
@@ -889,12 +881,10 @@ img.alignnone,
 	z-index: 10;
 	width: 100%;
 	height: 100%;
-	background: -moz-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
 	background: -webkit-gradient( linear, left top, left bottom, color-stop( 50%, rgba( 0, 0, 0, 0 ) ), color-stop( 51%, rgba( 0, 0, 0, 0 ) ), color-stop( 100%, rgba( 0, 0, 0, 0.72 ) ) );
-	background: -webkit-linear-gradient( top, rgba( 0, 0, 0, 0) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
-	background: -o-linear-gradient( top, rgba( 0, 0, 0, 0) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
-	background: -ms-linear-gradient( top, rgba( 0, 0, 0, 0) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
-	background: linear-gradient( to bottom, rgba( 0, 0, 0, 0) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
+	background: -webkit-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
+	background: -moz-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
+	background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#b8000000', GradientType=0 );
 }
 .featured-image.empty .share {
@@ -921,12 +911,10 @@ img.alignnone,
 	height: 100%;
 }
 .slider .slide {
+	display: none;
 	position: relative;
 	overflow: hidden;
 	height: 500px;
-}
-.slider .slide {
-	display: none;
 }
 .slider .slide:first-child {
 	display: block;
@@ -940,7 +928,6 @@ img.alignnone,
 	margin: 0 auto;
 	background: transparent repeat left center;
 }
-
 .slider .container {
 	position: absolute;
 	bottom: 0;
@@ -958,11 +945,11 @@ img.alignnone,
 	right: 12px;
 	font-size: 11px;
 	letter-spacing: 1px;
-	color: rgba( 255, 255, 255, .6 );
+	color: rgba( 255, 255, 255, 0.6 );
 }
 .slider .author-credentials a {
 	text-decoration: underline;
-	color: rgba( 255, 255, 255, .6 );
+	color: rgba( 255, 255, 255, 0.6 );
 }
 .slider .author-credentials a:hover {
 	color: rgba( 255, 255, 255, 1 );
@@ -1000,11 +987,9 @@ img.alignnone,
 	z-index: 10;
 	width: 100%;
 	height: 100%;
-	background: -moz-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
 	background: -webkit-gradient( linear, left top, left bottom, color-stop( 50%, rgba( 0, 0, 0, 0 ) ), color-stop( 51%, rgba( 0, 0, 0, 0 ) ), color-stop( 100%, rgba( 0, 0, 0, 0.72 ) ) );
 	background: -webkit-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
-	background: -o-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
-	background: -ms-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
+	background: -moz-linear-gradient( top, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
 	background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 50%, rgba( 0, 0, 0, 0 ) 51%, rgba( 0, 0, 0, 0.72 ) 100% );
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#b8000000', GradientType=0 );
 }
@@ -1018,12 +1003,10 @@ img.alignnone,
 	padding: 27px 20px 26px;
 	color: #444;
 	background: rgba( 255, 255, 255, 0.95 );
+	text-align: center;
 	-webkit-transform: translateX( -50% ) translateY( -50% );
 	-ms-transform: translateX( -50% ) translateY( -50% );
 	transform: translateX( -50% ) translateY( -50% );
-}
-.slider .entry {
-	text-align: center;
 }
 .slider .entry .category {
 	padding-bottom: 7px;
@@ -1060,7 +1043,7 @@ img.alignnone,
 	padding: 0 7px 0 3px;
 }
 
-.slider-post-text {}
+/* .slider-post-text {} */
 
 
 /* ------------------------------------------------------------ *\
@@ -1426,6 +1409,7 @@ img.alignnone,
 .widget_community .image {
 	display: block;
 	width: 100%;
+	margin-bottom: 7px;
 }
 .widget_community .image img {
 	display: block;
@@ -1442,9 +1426,6 @@ img.alignnone,
 .widget_community h5 a:hover {
 	text-decoration: none;
 	color: #000;
-}
-.widget_community .image {
-	margin-bottom: 7px;
 }
 .widget_community .link-more {
 	padding-top: 5px;
@@ -1662,12 +1643,10 @@ img.alignnone,
 	color: #444;
 }
 .widget_recent_comments li {
-	margin-bottom: 11px;
-}
-.widget_recent_comments li {
 	position: relative;
 	display: block;
 	padding: 11px 23px;
+	margin-bottom: 11px;
 	color: #444;
 	background: #fafafa;
 }
@@ -1736,7 +1715,7 @@ img.alignnone,
 	-moz-transition: all 200ms cubic-bezier( 0.39, 0.575, 0.565, 1 );
 	transition: all 200ms cubic-bezier( 0.39, 0.575, 0.565, 1 );
 }
-.widget #mc_embed_signup .mc-field-group input[type="email"]:focus {
+.widget #mc_embed_signup .mc-field-group input[type='email']:focus {
 	border-color: #36c;
 	box-shadow: inset 0 0 0 1px #36c;
 	outline: 0;
@@ -1925,8 +1904,8 @@ img.alignnone,
 
 a,
 button,
-input[type="button"],
-input[type="submit"],
+input[type='button'],
+input[type='submit'],
 .comments .navigation .more {
 	-webkit-transition: color 0.3s ease, background 0.3s ease, opacity 0.3s ease;
 	transition: color 0.3s ease, background 0.3s ease, opacity 0.3s ease;
@@ -2113,7 +2092,7 @@ input[type="submit"],
 		width: 100%;
 		max-width: none;
 		padding: 0;
-		margin: 30px 0 !important;
+		margin: 30px 0 !important; /* stylelint-disable-line declaration-no-important */
 	}
 	.article-body .image img {
 		width: 100%;
@@ -2153,7 +2132,7 @@ input[type="submit"],
 	.comments .children {
 		padding-left: 30px;
 	}
-	.comment-respond input[type="text"],
+	.comment-respond input[type='text'],
 	.comment-respond textarea {
 		width: 100%;
 	}
@@ -2324,7 +2303,7 @@ input[type="submit"],
 		margin: 8px auto 6px;
 		font-size: 0;
 		line-height: 0;
-		background: rgba( 71, 71, 71, .6 );
+		background: rgba( 71, 71, 71, 0.6 );
 	}
 
 	.article-description {
@@ -2332,7 +2311,7 @@ input[type="submit"],
 	}
 
 	.article-body .image {
-		margin: 0 0 20px !important;
+		margin: 0 0 20px !important; /* stylelint-disable-line declaration-no-important */
 	}
 
 	.article-image {
@@ -2394,7 +2373,7 @@ input[type="submit"],
 		overflow-x: hidden;
 		width: 260px;
 		height: 100%;
-		background: rgba( 255, 255, 255, .98 );
+		background: rgba( 255, 255, 255, 0.98 );
 		-webkit-overflow-scrolling: touch;
 	}
 	.wrapper {
@@ -2407,11 +2386,11 @@ input[type="submit"],
 		content: '';
 		position: fixed;
 		top: 0;
-		right: 0px;
+		right: 0;
 		left: 0;
 		z-index: 200;
 		height: 100%;
-		background: rgba( 0, 0, 0, .60 );
+		background: rgba( 0, 0, 0, 0.6 );
 		visibility: hidden;
 		opacity: 0;
 	}


### PR DESCRIPTION
Introducing stylelint and wikimedia-config-stylelint to follow
CSS Coding Guidelines. npm and Grunt are needed dependencies.
Also making CSS pass stylelint rules with several nullified
exceptions in .stylelintrc not to be overwhelming changes
in the beginning. Grunt was chosen over competing software
solutions as majority of WMF software makes use of it.
Also removing unnecessary gradient vendor prefixes.