### PR TITLE
Replace protocol-relative URLs with HTTPS

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 require_once( WP_CONTENT_DIR . '/themes/vip/plugins/vip-init.php' );
 
@@ -207,15 +207,15 @@ function wmb_thumbnail_caption() {
 
 	$thumbnail = get_post( get_post_meta( get_the_ID(), '_thumbnail_id', true ) );
 	if( $thumbnail && $thumbnail->post_excerpt ) {
-		echo '<p class="img-info">' . nl2br( strip_tags( $thumbnail->post_excerpt, '<a>' ) ) . '</p>';		
+		echo '<p class="img-info">' . nl2br( strip_tags( $thumbnail->post_excerpt, '<a>' ) ) . '</p>';
 	}
 }
 
 # Disable media embeds in comments, for reader privacy reasons
-# per http://lobby.vip.wordpress.com/2014/09/04/coming-soon-enabling-embeds-in-comments/
+# per https://lobby.vip.wordpress.com/2014/09/04/coming-soon-enabling-embeds-in-comments/
 add_filter( 'wpcom_vip_enable_full_comment_embeds', '__return_false' );
 
-# Deactivate anti-widowing (http://vip.wordpress.com/functions/widont/ ) because
+# Deactivate anti-widowing (https://vip.wordpress.com/functions/widont/ ) because
 # it often causes post titles in the "Featured posts" list to run into the image
 # per https://wordpressvip.zendesk.com/requests/33250
 remove_filter( 'the_title', 'widont' );
@@ -235,5 +235,5 @@ add_filter( 'infinite_scroll_js_settings', 'wmb_filter_jetpack_infinite_scroll_j
 
 # Default to HTTPS canonical URLs
 add_filter( 'rel_canonical', function( $canonical_url ) {
-	return  str_replace( 'http://', 'https://', $canonical_url );
+	return str_replace( 'http://', 'https://', $canonical_url );
 } );

--- a/includes/commons.php
+++ b/includes/commons.php
@@ -25,9 +25,9 @@ function wmb_content_load_page() {
 	global $post;
 	media_upload_header();
 	?>
-    <div class="describe" style="margin: 20px;">Image URL: 
+    <div class="describe" style="margin: 20px;">Image URL:
 		<input id="src" type="text" name="imageurl" style="font-size: 18px;padding: 12px 14px;width: 100%;"><br/>
-		<div class="help-text" style="font-size:13px;color: #000088;padding: 5px;">You MUST use an image URL that specifies the width (i.e. <i>http://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Bald_Eagle_Head_sq.jpg/768px-Bald_Eagle_Head_sq.jpg</i>)</div>
+		<div class="help-text" style="font-size:13px;color: #000088;padding: 5px;">You MUST use an image URL that specifies the width (i.e. <i>https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Bald_Eagle_Head_sq.jpg/768px-Bald_Eagle_Head_sq.jpg</i>)</div>
 		<input type="submit" id="loadImage" value="Upload">
 		<div id="succes"></div>
     </div>
@@ -35,7 +35,7 @@ function wmb_content_load_page() {
 }
 
 add_action( 'admin_enqueue_scripts', 'wmb_commons_caption' );
-function wmb_commons_caption( $hook ) { 
+function wmb_commons_caption( $hook ) {
     wp_deregister_script( 'upload-media-script' );
     wp_register_script( 'upload-media-script', get_template_directory_uri() . '/js/caption-from-commons.js' );
     wp_enqueue_script( 'upload-media-script' );
@@ -99,7 +99,7 @@ function wmb_media_upload_type_form1( $type = 'file', $errors = null, $id = null
 
 	<?php
 }
-  
+
 function wmb_custom_attachments_fields( $form_fields, $post ) {
     $field_value = get_post_meta( $post->ID, 'post_excerpt', true );
     $allowed_html = array(
@@ -132,13 +132,13 @@ function wmb_ajax_get_commons_data() {
 	$url_without_width = str_replace( $from_last_slash, '', $url ); // remove part of string containing width
 	$filename = strrchr( $url_without_width, '/' ); // get filename with leading slash
 	$filename = substr( $filename, 1 ); // remove leading slash
-	
+
 	if ( ! $width || ! $filename ) {
 		wmb_ajax_error();
 	}
 
-	$xml = wmb_get_xml( 'http://tools.wmflabs.org/magnus-toolserver/commonsapi.php?image=' . $filename . '&thumbwidth=' . $width );
-	
+	$xml = wmb_get_xml( 'https://tools.wmflabs.org/magnus-toolserver/commonsapi.php?image=' . $filename . '&thumbwidth=' . $width );
+
 	if ( !$xml || property_exists( $xml, 'error' ) ) {
 		wmb_ajax_error();
 	}
@@ -152,7 +152,7 @@ function wmb_ajax_get_commons_data() {
 	$post_id = absint( $_POST['post_id'] );
 	$desc = $commons_filename;
 	$commons_url = str_replace( 'http:', 'https:', $xml->file->urls->description );
-	$caption = '<a href="' . esc_url( $commons_url ) . '">"' . esc_html( $commons_filename ) . '"</a> by <a href="' . esc_url( $commons_uploader_url ) . '">' . esc_html( $commons_uploader ) . 
+	$caption = '<a href="' . esc_url( $commons_url ) . '">"' . esc_html( $commons_filename ) . '"</a> by <a href="' . esc_url( $commons_uploader_url ) . '">' . esc_html( $commons_uploader ) .
 	  '</a>, under <a href="' . esc_url( $xml->licenses->license->license_text_url ) . '">' . esc_html( $xml->licenses->license->name ) . '</a>';
 
 	if ( function_exists( 'wpcom_vip_download_image' ) ) {
@@ -177,7 +177,7 @@ function wmb_ajax_get_commons_data() {
 }
 
 add_filter( 'attachment_link', 'wmb_filter_attachment_link', 10, 2 );
-function wmb_filter_attachment_link( $link, $postID = 0 ) { 
+function wmb_filter_attachment_link( $link, $postID = 0 ) {
 	update_option( 'image_default_link_type', 'post' );
 
 	$commons_attach = get_post_meta( $postID, 'commons_attach', true );
@@ -185,5 +185,5 @@ function wmb_filter_attachment_link( $link, $postID = 0 ) {
 		$commons_attach = $link;
 	}
 
-	return $commons_attach;	
+	return $commons_attach;
 }

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -18,8 +18,8 @@ function wmb_register_widgets() {
 class WMB_Social_Links extends WP_Widget {
 
 	function __construct() {
-		parent::__construct( 'WMB_Social_Links', 'WikiMedia - Social Links', array( 
-			'description' => 'Displays a widget with social links, managed from Appearance -> Options.', 
+		parent::__construct( 'WMB_Social_Links', 'WikiMedia - Social Links', array(
+			'description' => 'Displays a widget with social links, managed from Appearance -> Options.',
 			'classname' => 'widget_connect'
 		) );
 	}
@@ -61,7 +61,7 @@ class WMB_Social_Links extends WP_Widget {
 			'twitter' => 'twitter',
 			'linkedin' => 'linkedin',
 			'rss' => 'rss',
-		);	
+		);
 
 		foreach ($socials as $classname => $option_name) {
 			$option_key = $option_name . '_link';
@@ -103,10 +103,10 @@ class WMB_Subscribe_Widget extends WP_Widget {
 		}
 		?>
 		<p>
-			<label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_attr_e( 'Title:', 'wmb' ); ?></label> 
+			<label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_attr_e( 'Title:', 'wmb' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 		</p>
-		<?php 
+		<?php
 	}
 
 	function update( $new_instance, $old_instance ) {
@@ -126,22 +126,22 @@ class WMB_Subscribe_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', $instance['title'] );
 		echo wp_kses_post( $before_widget );
 
-		if ( !empty( $title ) ) { 
-			echo wp_kses_post( $before_title ) . esc_html( $title ) . wp_kses_post( $after_title ); 
+		if ( !empty( $title ) ) {
+			echo wp_kses_post( $before_title ) . esc_html( $title ) . wp_kses_post( $after_title );
 		}
 
 		?>
 
 		<!-- Begin MailChimp Signup Form -->
-		<link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
-		
+		<link href="https://cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
+
 		<div id="mc_embed_signup">
-			<form action="//wikimediafoundation.us11.list-manage.com/subscribe/post?u=7e010456c3e448b30d8703345&amp;id=246cd15c56" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+			<form action="https://wikimediafoundation.us11.list-manage.com/subscribe/post?u=7e010456c3e448b30d8703345&amp;id=246cd15c56" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 			    <div id="mc_embed_signup_scroll">
 					<div class="mc-field-group email">
 						<input type="email" placeholder="Your email address" name="EMAIL" class="email" id="mce-EMAIL">
 					</div>
-					
+
 					<div class="clear"></div>
 
 					<div class="mc-field-group input-group">
@@ -152,21 +152,22 @@ class WMB_Subscribe_Widget extends WP_Widget {
 					</div>
 
 					<input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
-						
+
 					<div id="mce-responses" class="clear">
 						<div class="response" id="mce-error-response" style="display:none"></div>
 						<div class="response" id="mce-success-response" style="display:none"></div>
-					</div>    
+					</div>
 					<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
 				    <div style="position: absolute; left: -5000px;"><input type="text" name="b_7e010456c3e448b30d8703345_246cd15c56" tabindex="-1" value=""></div>
-			    
+
 			    </div>
 			</form>
 		</div>
-		<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
-		<script type='text/javascript' src='<?php echo esc_url( get_template_directory_uri() ); ?>/js/subscribe.js'></script>
+		<script src='https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script>
+		<script>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+		<script src='<?php echo esc_url( get_template_directory_uri() ); ?>/js/subscribe.js'></script>
 		<!--End mc_embed_signup-->
-		<?php 
+		<?php
 		echo wp_kses_post( $after_widget );
 	}
 
@@ -178,8 +179,8 @@ class WMB_Subscribe_Widget extends WP_Widget {
 class WMB_Category_Posts extends WP_Widget {
 
 	function __construct() {
-		parent::__construct('WMB_Category_Posts', 'WikiMedia - Category Posts', array( 
-			'description' => 'Displays a widget with most recent posts from a certain category.', 
+		parent::__construct('WMB_Category_Posts', 'WikiMedia - Category Posts', array(
+			'description' => 'Displays a widget with most recent posts from a certain category.',
 			'classname' => 'widget_community'
 		));
 	}
@@ -240,7 +241,7 @@ class WMB_Category_Posts extends WP_Widget {
 			'posts_per_page' => $total_posts,
 			'cat' => $instance['post_category'],
 		);
-		$posts = new WP_Query( $query_args ); 
+		$posts = new WP_Query( $query_args );
 
 		if ( $posts->have_posts() ) {
 			?>
@@ -261,7 +262,7 @@ class WMB_Category_Posts extends WP_Widget {
 					</li>
 				<?php endwhile; ?>
 			</ul>
-		
+
 			<?php
 
 			if ( !empty( $instance['more_link_text'] ) ) {
@@ -293,8 +294,8 @@ class WMB_Category_Posts extends WP_Widget {
 class WMB_Most_Viewed_Posts extends WP_Widget {
 
 	function __construct() {
-		parent::__construct('WMB_Most_Viewed_Posts', 'WikiMedia - Most Viewed Posts', array( 
-			'description' => 'Displays a widget with most viewed posts within a certain number of days.', 
+		parent::__construct('WMB_Most_Viewed_Posts', 'WikiMedia - Most Viewed Posts', array(
+			'description' => 'Displays a widget with most viewed posts within a certain number of days.',
 			'classname' => 'widget_most_viewed'
 		));
 	}
@@ -397,8 +398,8 @@ class WMB_Most_Viewed_Posts extends WP_Widget {
 class WMB_Custom_Quote extends WP_Widget {
 
 	function __construct() {
-		parent::__construct('WMB_Custom_Quote', 'WikiMedia - Custom Quote', array( 
-			'description' => 'Displays a widget with a custom quote.', 
+		parent::__construct('WMB_Custom_Quote', 'WikiMedia - Custom Quote', array(
+			'description' => 'Displays a widget with a custom quote.',
 			'classname' => 'widget_quote'
 		));
 	}
@@ -437,7 +438,7 @@ class WMB_Custom_Quote extends WP_Widget {
 					<?php echo wp_kses_post( apply_filters( 'the_content', $instance['quote'] ) ); ?>
 				</div><!-- /.entry -->
 			<?php endif ?>
-			
+
 			<?php if ( !empty( $instance['author'] ) ): ?>
 				<p class="meta">
 					<?php echo wp_kses_post( nl2br( $instance['author'] ) ); ?>
@@ -457,8 +458,8 @@ class WMB_Custom_Quote extends WP_Widget {
 class WMB_Archives extends WP_Widget {
 
 	function __construct() {
-		parent::__construct('WMB_Archives', 'WikiMedia - Archives', array( 
-			'description' => 'Displays a widget with a custom archives.', 
+		parent::__construct('WMB_Archives', 'WikiMedia - Archives', array(
+			'description' => 'Displays a widget with a custom archives.',
 			'classname' => 'widget_archive'
 		));
 	}
@@ -507,11 +508,11 @@ class WMB_Archives extends WP_Widget {
 		}
 
 		echo '<li class="older-posts"><a href="#">' . esc_html__( 'Older Posts', 'wmb' ) . '</a>&nbsp;(' . esc_html( $total_posts ) . ')</li>';
-		
+
 		wp_get_archives( array(
 			'type' => 'yearly',
 			'show_post_count' => true,
-		) );		
+		) );
 
 		echo '</ul>';
 

--- a/js/jquery.eventlogging.js
+++ b/js/jquery.eventlogging.js
@@ -1,4 +1,4 @@
-(function ($) {
+( function ( $ ) {
 	$( function () {
 
 		function urlStripProto( url ) {
@@ -28,7 +28,7 @@
 				capsule[ 'event' ][ 'referrerUrl' ] = urlStripProto( document.referrer );
 			}
 			var beacon = document.createElement( 'img' );
-			beacon.src = '//www.wikimedia.org/beacon/event?' + encodeURIComponent( $.toJSON( capsule ) ) + ';';
+			beacon.src = 'https://www.wikimedia.org/beacon/event?' + encodeURIComponent( $.toJSON( capsule ) ) + ';';
 		}, 0 );
 	} );
-}(jQuery));
+}( jQuery ) );


### PR DESCRIPTION
Replacing `//` with explicite HTTPS URLs, including documentation links.
Also cleaning up some whitespace errors.

Bug: T162394