### PR TITLE
Add OpenGraph tags and twitter meta tags for having cards when sharing in social media

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -244,3 +244,4 @@ function wmb_filter_shortlink( $shortlink, $id, $context ) {
     return str_replace( 'http://', 'https://', $shortlink );
 }
 
+wpcom_vip_enable_opengraph();

--- a/header.php
+++ b/header.php
@@ -6,9 +6,6 @@
 	<link rel="shortcut icon" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/favicon.ico" />
 	<link rel="pingback" href="<?php echo esc_attr( get_bloginfo( 'pingback_url' ) ); ?>" />
 <?php if ( is_single() ) {
-	echo '<meta property="og:image" content="' . htmlspecialchars ( get_the_post_thumbnail( 'large' ) ) . '"/>';
-	echo '<meta property="og:description" content="' . htmlspecialchars( get_bloginfo( 'description' ) ) . '"/>';
-	echo '<meta property="og:title" content="' . htmlspecialchars( get_the_title() ) . '"/>';
 	echo '<meta name="twitter:card" content="summary_large_image">';
 	echo '<meta name="twitter:site" content="@wikimedia">';
 }

--- a/header.php
+++ b/header.php
@@ -6,9 +6,9 @@
 	<link rel="shortcut icon" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/favicon.ico" />
 	<link rel="pingback" href="<?php echo esc_attr( get_bloginfo( 'pingback_url' ) ); ?>" />
 <?php if ( is_single() ) {
-	echo '<meta property="og:image" content="' . the_post_thumbnail( 'large' ) . '"/>';
-	echo '<meta property="og:description" content="' . bloginfo( 'description' ) . '"/>';
-	echo '<meta property="og:title" content="' . single_post_title() . '"/>';
+	echo '<meta property="og:image" content="' . htmlspecialchars ( get_the_post_thumbnail( 'large' ) ) . '"/>';
+	echo '<meta property="og:description" content="' . htmlspecialchars( get_bloginfo( 'description' ) ) . '"/>';
+	echo '<meta property="og:title" content="' . htmlspecialchars( get_the_title() ) . '"/>';
 	echo '<meta name="twitter:card" content="summary_large_image">';
 	echo '<meta name="twitter:site" content="@wikimedia">';
 }

--- a/header.php
+++ b/header.php
@@ -5,8 +5,15 @@
 	
 	<link rel="shortcut icon" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/favicon.ico" />
 	<link rel="pingback" href="<?php echo esc_attr( get_bloginfo( 'pingback_url' ) ); ?>" />
+<?php if ( is_single() ) {
+	echo '<meta property="og:image" content="' . the_post_thumbnail( 'large' ) . '"/>';
+	echo '<meta property="og:description" content="' . bloginfo( 'description' ) . '"/>';
+	echo '<meta property="og:title" content="' . single_post_title() . '"/>';
+	echo '<meta name="twitter:card" content="summary_large_image">';
+	echo '<meta name="twitter:site" content="@wikimedia">';
+}
 
-	<?php wp_head(); ?>
+wp_head();?>
 </head>
 <body <?php body_class(); ?>>
 


### PR DESCRIPTION
This would help greatly if we want to share in twitter or facebook and shows a nice little card. We already done that for Wikipedia articles and Wikidata items.

Useful links:
 - https://codex.wordpress.org/Meta_Tags_in_WordPress
 - https://dev.twitter.com/cards/types/summary-large-image
 - https://developers.facebook.com/docs/sharing/web